### PR TITLE
#149 質問投稿時のキューを保存する処理の追加

### DIFF
--- a/app/_api/collections/queue.ts
+++ b/app/_api/collections/queue.ts
@@ -1,0 +1,30 @@
+import {
+  DocumentData,
+  addDoc,
+  CollectionReference,
+  collection,
+} from "firebase/firestore";
+import { Collection } from "./collection";
+
+export class QueueCollection extends Collection {
+  public collectionRef: CollectionReference<any, DocumentData>;
+
+  constructor() {
+    super();
+    this.collectionRef = collection(this.firestore, "queues");
+  }
+
+  // キューを作成する
+  async saveQueue(sort: string, props: any) {
+    try {
+      await addDoc(this.collectionRef, {
+        params: props,
+        sort: sort,
+        expired_at: null,
+        is_synced: false,
+      });
+    } catch {
+      throw new Error("キューの保存に失敗しました");
+    }
+  }
+}

--- a/app/_api/endpoints/island_question.ts
+++ b/app/_api/endpoints/island_question.ts
@@ -37,7 +37,7 @@ export async function createQuestion(
     const queue = new QueueCollection();
     analytics.logCreateQuestion(islandId);
 
-    Promise.all([
+    await Promise.all([
       q.SaveQuestion(userId, question),
       p.updatePostedQuestions(),
       a.SaveActivity(islandId, notificationTypes.QUESTION, question, ""),

--- a/app/_api/endpoints/island_question.ts
+++ b/app/_api/endpoints/island_question.ts
@@ -3,6 +3,8 @@ import { UserProfileCollection } from "../collections/user_profile";
 import { UserActivityCollection } from "../collections/user_activity";
 import { notificationTypes } from "@/app/_constants/notification_types";
 import { FirebaseAnalytics } from "../analytics";
+import { QueueCollection } from "../collections/queue";
+import { queues } from "@/app/_constants/queues";
 
 const analytics = new FirebaseAnalytics();
 
@@ -32,12 +34,16 @@ export async function createQuestion(
     const q = new IslandQuestionCollection(islandId);
     const p = new UserProfileCollection(userId);
     const a = new UserActivityCollection(userId);
+    const queue = new QueueCollection();
     analytics.logCreateQuestion(islandId);
 
     Promise.all([
       q.SaveQuestion(userId, question),
       p.updatePostedQuestions(),
       a.SaveActivity(islandId, notificationTypes.QUESTION, question, ""),
+      queue.saveQueue(queues.QUESTION, {
+        island_id: islandId,
+      }),
     ]);
 
     return true;

--- a/app/_components/util/common_dialog.tsx
+++ b/app/_components/util/common_dialog.tsx
@@ -29,7 +29,7 @@ export default function CommonDialog() {
 
   return (
     <Dialog
-      maxWidth={"md"}
+      fullWidth
       open={dialogState.isShown}
       onClose={() => hideDialog()}
       sx={{ overflow: "auto" }}

--- a/app/_constants/queues.ts
+++ b/app/_constants/queues.ts
@@ -1,0 +1,5 @@
+// queuesで使用する定数
+export const queues = {
+  QUESTION: "question",
+  ANSWER: "answer",
+};


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- New Feature: `QueueCollection`クラスに新しいメソッド`saveQueue`が追加されました。これにより、指定されたパラメータとソートキーを使用してキューを作成し、Firebase Firestoreに保存することができます。
- New Feature: `createQuestion`関数にキューの保存処理が追加されました。`QueueCollection`と`queues`が新たにインポートされ、`queue.saveQueue`メソッドが呼び出されています。
- Chore: `queues`オブジェクトがエクスポートされ、`QUESTION`と`ANSWER`の2つのキューが追加されました。

Note: このプルリクエストは、新機能やバグ修正ではなく、外部インターフェースやコードの振る舞いに影響を与える可能性があるため、注意深く評価する必要があります。
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->