### PR TITLE
#148 質問・回答投稿時にキューを作成する処理を追加

### DIFF
--- a/app/_api/collections/queue.ts
+++ b/app/_api/collections/queue.ts
@@ -1,0 +1,30 @@
+import {
+  DocumentData,
+  addDoc,
+  CollectionReference,
+  collection,
+} from "firebase/firestore";
+import { Collection } from "./collection";
+
+export class QueueCollection extends Collection {
+  public collectionRef: CollectionReference<any, DocumentData>;
+
+  constructor() {
+    super();
+    this.collectionRef = collection(this.firestore, "queues");
+  }
+
+  // キューを作成する
+  async saveQueue(sort: string, props: any) {
+    try {
+      await addDoc(this.collectionRef, {
+        params: props,
+        sort: sort,
+        expired_at: null,
+        is_synced: false,
+      });
+    } catch {
+      throw new Error("キューの保存に失敗しました");
+    }
+  }
+}

--- a/app/_api/endpoints/island_question.ts
+++ b/app/_api/endpoints/island_question.ts
@@ -37,7 +37,7 @@ export async function createQuestion(
     const queue = new QueueCollection();
     analytics.logCreateQuestion(islandId);
 
-    Promise.all([
+    await Promise.all([
       q.SaveQuestion(userId, question),
       p.updatePostedQuestions(),
       a.SaveActivity(islandId, notificationTypes.QUESTION, question, ""),

--- a/app/_api/endpoints/island_question.ts
+++ b/app/_api/endpoints/island_question.ts
@@ -3,6 +3,8 @@ import { UserProfileCollection } from "../collections/user_profile";
 import { UserActivityCollection } from "../collections/user_activity";
 import { notificationTypes } from "@/app/_constants/notification_types";
 import { FirebaseAnalytics } from "../analytics";
+import { QueueCollection } from "../collections/queue";
+import { queues } from "@/app/_constants/queues";
 
 const analytics = new FirebaseAnalytics();
 
@@ -32,12 +34,16 @@ export async function createQuestion(
     const q = new IslandQuestionCollection(islandId);
     const p = new UserProfileCollection(userId);
     const a = new UserActivityCollection(userId);
+    const queue = new QueueCollection();
     analytics.logCreateQuestion(islandId);
 
     Promise.all([
       q.SaveQuestion(userId, question),
       p.updatePostedQuestions(),
       a.SaveActivity(islandId, notificationTypes.QUESTION, question, ""),
+      queue.saveQueue(queues.QUESTION, {
+        island_id: islandId,
+      }),
     ]);
 
     return true;

--- a/app/_api/endpoints/question_answer.ts
+++ b/app/_api/endpoints/question_answer.ts
@@ -5,7 +5,6 @@ import { UserActivityCollection } from "../collections/user_activity";
 import { UserProfileCollection } from "../collections/user_profile";
 import { UserReactionCollection } from "../collections/user_reaction";
 import { FirebaseAnalytics } from "../analytics";
-import { Queue } from "@mui/icons-material";
 import { QueueCollection } from "../collections/queue";
 import { queues } from "@/app/_constants/queues";
 

--- a/app/_api/endpoints/question_answer.ts
+++ b/app/_api/endpoints/question_answer.ts
@@ -5,6 +5,9 @@ import { UserActivityCollection } from "../collections/user_activity";
 import { UserProfileCollection } from "../collections/user_profile";
 import { UserReactionCollection } from "../collections/user_reaction";
 import { FirebaseAnalytics } from "../analytics";
+import { Queue } from "@mui/icons-material";
+import { QueueCollection } from "../collections/queue";
+import { queues } from "@/app/_constants/queues";
 
 const analytics = new FirebaseAnalytics();
 
@@ -31,6 +34,7 @@ export async function createAnswer(
       const p = new UserProfileCollection(userId);
       const act = new UserActivityCollection(userId);
       const reaction = new UserReactionCollection(questionerId);
+      const queue = new QueueCollection();
 
       await Promise.all([
         ans.saveAnswer(answer, optionUrl, userId),
@@ -42,6 +46,10 @@ export async function createAnswer(
           notificationTypes.ANSWER_QUESTION,
           content
         ),
+        queue.saveQueue(queues.ANSWER, {
+          island_id: islandId,
+          question_id: questionId,
+        }),
       ]);
     });
 

--- a/app/_components/util/common_dialog.tsx
+++ b/app/_components/util/common_dialog.tsx
@@ -29,7 +29,7 @@ export default function CommonDialog() {
 
   return (
     <Dialog
-      maxWidth={"md"}
+      fullWidth
       open={dialogState.isShown}
       onClose={() => hideDialog()}
       sx={{ overflow: "auto" }}

--- a/app/_constants/queues.ts
+++ b/app/_constants/queues.ts
@@ -1,0 +1,5 @@
+// queuesで使用する定数
+export const queues = {
+  QUESTION: "question",
+  ANSWER: "answer",
+};


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- New Feature: `QueueCollection`クラスと`saveQueue`メソッドが追加されました。これにより、指定されたパラメータでキューを作成することができます。
- New Feature: `island_question.ts`の`createQuestion`関数にキュー作成の処理が追加されました。`QueueCollection`と`queues`がインポートされ、`queue.saveQueue`メソッドが呼び出されています。
- New Feature: `question_answer.ts`には、質問・回答投稿時にキューを作成する処理が追加されています。`QueueCollection`という新しいクラスが導入され、`queues`という定数も使用されています。
- New Feature: `queues.ts`では、`queues`オブジェクトがエクスポートされ、`QUESTION`と`ANSWER`の2つのキューが定義されています。これにより、質問と回答の投稿時に使用されるキューが準備されます。
- Style: `common_dialog.tsx`の変更により、CommonDialogコンポーネントの幅が最大値ではなくフルウィズに設定されるようになりました。これにより、ダイアログが画面全体を占めるようになります。

Note: このプルリクエストは`NEEDS_REVIEW`としてトリアージされました。変更はマイナーなものですが、外部インターフェースや動作に影響を与える可能性があるため、レビューが必要です。また、ダイアログの表示方法の変更は他のコンポーネントやスタイルにも影響を及ぼす可能性があります。
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->